### PR TITLE
Fix: Correct import and compile -l flag

### DIFF
--- a/ortools.go
+++ b/ortools.go
@@ -6,7 +6,7 @@ package ortools
 import (
 	"fmt"
 
-	"github.com/gonzojive/or-tools-go/ortools/ortoolsswig"
+	"github.com/gonzojive/or-tools-go/ortoolsswig"
 )
 
 // ProblemType is a type of OptimizationProblemType supported by the OR Tools library.

--- a/ortoolsswig/ortoolsswig.go
+++ b/ortoolsswig/ortoolsswig.go
@@ -12,6 +12,8 @@
 
 package ortoolsswig
 
+// #cgo CXXFLAGS: -std=c++17
+// #cgo LDFLAGS: -lortools
 /*
 #define intgo swig_intgo
 typedef void *swig_voidp;
@@ -215,28 +217,26 @@ import "unsafe"
 import _ "runtime/cgo"
 import "sync"
 
-
 type _ unsafe.Pointer
-
-
 
 var Swig_escape_always_false bool
 var Swig_escape_val interface{}
 
-
 type _swig_fnptr *byte
 type _swig_memberptr *byte
 
-
 type _ sync.Mutex
 
+type swig_gostring struct {
+	p uintptr
+	n int
+}
 
-type swig_gostring struct { p uintptr; n int }
 func swigCopyString(s string) string {
-  p := *(*swig_gostring)(unsafe.Pointer(&s))
-  r := string((*[0x7fffffff]byte)(unsafe.Pointer(p.p))[:p.n])
-  Swig_free(p.p)
-  return r
+	p := *(*swig_gostring)(unsafe.Pointer(&s))
+	r := string((*[0x7fffffff]byte)(unsafe.Pointer(p.p))[:p.n])
+	Swig_free(p.p)
+	return r
 }
 
 func Swig_free(arg1 uintptr) {
@@ -247,6 +247,7 @@ func Swig_free(arg1 uintptr) {
 const ABSL_HAVE_ATTRIBUTE_NO_TAIL_CALL int = 0
 const ABSL_HAVE_ATTRIBUTE_WEAK int = 0
 const ABSL_HAVE_ATTRIBUTE_SECTION int = 0
+
 func _swig_getABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE() (_swig_ret int) {
 	var swig_r int
 	swig_r = (int)(C._wrap_ABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE_ortoolsswig_fe88f1954daf0526())
@@ -254,6 +255,7 @@ func _swig_getABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE() (_swig_ret int) {
 }
 
 var ABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE int = _swig_getABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE()
+
 type SwigcptrSolver uintptr
 
 func (p SwigcptrSolver) Swigcptr() uintptr {
@@ -264,6 +266,7 @@ func (p SwigcptrSolver) SwigIsSolver() {
 }
 
 type Operations_researchMPSolverOptimizationProblemType int
+
 func _swig_getSolver_CLP_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_CLP_LINEAR_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -271,6 +274,7 @@ func _swig_getSolver_CLP_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_resea
 }
 
 var SolverCLP_LINEAR_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_CLP_LINEAR_PROGRAMMING_Solver()
+
 func _swig_getSolver_GLPK_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_GLPK_LINEAR_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -278,6 +282,7 @@ func _swig_getSolver_GLPK_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_rese
 }
 
 var SolverGLPK_LINEAR_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_GLPK_LINEAR_PROGRAMMING_Solver()
+
 func _swig_getSolver_GLOP_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_GLOP_LINEAR_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -285,6 +290,7 @@ func _swig_getSolver_GLOP_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_rese
 }
 
 var SolverGLOP_LINEAR_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_GLOP_LINEAR_PROGRAMMING_Solver()
+
 func _swig_getSolver_SCIP_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_SCIP_MIXED_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -292,6 +298,7 @@ func _swig_getSolver_SCIP_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operatio
 }
 
 var SolverSCIP_MIXED_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_SCIP_MIXED_INTEGER_PROGRAMMING_Solver()
+
 func _swig_getSolver_GLPK_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_GLPK_MIXED_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -299,6 +306,7 @@ func _swig_getSolver_GLPK_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operatio
 }
 
 var SolverGLPK_MIXED_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_GLPK_MIXED_INTEGER_PROGRAMMING_Solver()
+
 func _swig_getSolver_CBC_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_CBC_MIXED_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -306,6 +314,7 @@ func _swig_getSolver_CBC_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operation
 }
 
 var SolverCBC_MIXED_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_CBC_MIXED_INTEGER_PROGRAMMING_Solver()
+
 func _swig_getSolver_GUROBI_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_GUROBI_LINEAR_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -313,6 +322,7 @@ func _swig_getSolver_GUROBI_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_re
 }
 
 var SolverGUROBI_LINEAR_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_GUROBI_LINEAR_PROGRAMMING_Solver()
+
 func _swig_getSolver_GUROBI_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_GUROBI_MIXED_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -320,6 +330,7 @@ func _swig_getSolver_GUROBI_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operat
 }
 
 var SolverGUROBI_MIXED_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_GUROBI_MIXED_INTEGER_PROGRAMMING_Solver()
+
 func _swig_getSolver_CPLEX_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_CPLEX_LINEAR_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -327,6 +338,7 @@ func _swig_getSolver_CPLEX_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_res
 }
 
 var SolverCPLEX_LINEAR_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_CPLEX_LINEAR_PROGRAMMING_Solver()
+
 func _swig_getSolver_CPLEX_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_CPLEX_MIXED_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -334,6 +346,7 @@ func _swig_getSolver_CPLEX_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operati
 }
 
 var SolverCPLEX_MIXED_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_CPLEX_MIXED_INTEGER_PROGRAMMING_Solver()
+
 func _swig_getSolver_XPRESS_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_XPRESS_LINEAR_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -341,6 +354,7 @@ func _swig_getSolver_XPRESS_LINEAR_PROGRAMMING_Solver() (_swig_ret Operations_re
 }
 
 var SolverXPRESS_LINEAR_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_XPRESS_LINEAR_PROGRAMMING_Solver()
+
 func _swig_getSolver_XPRESS_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_XPRESS_MIXED_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -348,6 +362,7 @@ func _swig_getSolver_XPRESS_MIXED_INTEGER_PROGRAMMING_Solver() (_swig_ret Operat
 }
 
 var SolverXPRESS_MIXED_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_XPRESS_MIXED_INTEGER_PROGRAMMING_Solver()
+
 func _swig_getSolver_BOP_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_BOP_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -355,6 +370,7 @@ func _swig_getSolver_BOP_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_rese
 }
 
 var SolverBOP_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_BOP_INTEGER_PROGRAMMING_Solver()
+
 func _swig_getSolver_SAT_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_researchMPSolverOptimizationProblemType) {
 	var swig_r Operations_researchMPSolverOptimizationProblemType
 	swig_r = (Operations_researchMPSolverOptimizationProblemType)(C._wrap_SAT_INTEGER_PROGRAMMING_Solver_ortoolsswig_fe88f1954daf0526())
@@ -362,6 +378,7 @@ func _swig_getSolver_SAT_INTEGER_PROGRAMMING_Solver() (_swig_ret Operations_rese
 }
 
 var SolverSAT_INTEGER_PROGRAMMING Operations_researchMPSolverOptimizationProblemType = _swig_getSolver_SAT_INTEGER_PROGRAMMING_Solver()
+
 func NewSolver(arg1 string, arg2 Operations_researchMPSolverOptimizationProblemType) (_swig_ret Solver) {
 	var swig_r Solver
 	_swig_i_0 := arg1
@@ -556,6 +573,7 @@ func (arg1 SwigcptrSolver) Objective() (_swig_ret Objective) {
 }
 
 type Operations_researchMPSolverResultStatus int
+
 func _swig_getSolver_StatusOptimal_Solver() (_swig_ret Operations_researchMPSolverResultStatus) {
 	var swig_r Operations_researchMPSolverResultStatus
 	swig_r = (Operations_researchMPSolverResultStatus)(C._wrap_StatusOptimal_Solver_ortoolsswig_fe88f1954daf0526())
@@ -563,6 +581,7 @@ func _swig_getSolver_StatusOptimal_Solver() (_swig_ret Operations_researchMPSolv
 }
 
 var SolverStatusOptimal Operations_researchMPSolverResultStatus = _swig_getSolver_StatusOptimal_Solver()
+
 func _swig_getSolver_StatusFeasible_Solver() (_swig_ret Operations_researchMPSolverResultStatus) {
 	var swig_r Operations_researchMPSolverResultStatus
 	swig_r = (Operations_researchMPSolverResultStatus)(C._wrap_StatusFeasible_Solver_ortoolsswig_fe88f1954daf0526())
@@ -570,6 +589,7 @@ func _swig_getSolver_StatusFeasible_Solver() (_swig_ret Operations_researchMPSol
 }
 
 var SolverStatusFeasible Operations_researchMPSolverResultStatus = _swig_getSolver_StatusFeasible_Solver()
+
 func _swig_getSolver_StatusInfeasible_Solver() (_swig_ret Operations_researchMPSolverResultStatus) {
 	var swig_r Operations_researchMPSolverResultStatus
 	swig_r = (Operations_researchMPSolverResultStatus)(C._wrap_StatusInfeasible_Solver_ortoolsswig_fe88f1954daf0526())
@@ -577,6 +597,7 @@ func _swig_getSolver_StatusInfeasible_Solver() (_swig_ret Operations_researchMPS
 }
 
 var SolverStatusInfeasible Operations_researchMPSolverResultStatus = _swig_getSolver_StatusInfeasible_Solver()
+
 func _swig_getSolver_StatusUnbounded_Solver() (_swig_ret Operations_researchMPSolverResultStatus) {
 	var swig_r Operations_researchMPSolverResultStatus
 	swig_r = (Operations_researchMPSolverResultStatus)(C._wrap_StatusUnbounded_Solver_ortoolsswig_fe88f1954daf0526())
@@ -584,6 +605,7 @@ func _swig_getSolver_StatusUnbounded_Solver() (_swig_ret Operations_researchMPSo
 }
 
 var SolverStatusUnbounded Operations_researchMPSolverResultStatus = _swig_getSolver_StatusUnbounded_Solver()
+
 func _swig_getSolver_StatusAbnormal_Solver() (_swig_ret Operations_researchMPSolverResultStatus) {
 	var swig_r Operations_researchMPSolverResultStatus
 	swig_r = (Operations_researchMPSolverResultStatus)(C._wrap_StatusAbnormal_Solver_ortoolsswig_fe88f1954daf0526())
@@ -591,6 +613,7 @@ func _swig_getSolver_StatusAbnormal_Solver() (_swig_ret Operations_researchMPSol
 }
 
 var SolverStatusAbnormal Operations_researchMPSolverResultStatus = _swig_getSolver_StatusAbnormal_Solver()
+
 func _swig_getSolver_StatusNotSolved_Solver() (_swig_ret Operations_researchMPSolverResultStatus) {
 	var swig_r Operations_researchMPSolverResultStatus
 	swig_r = (Operations_researchMPSolverResultStatus)(C._wrap_StatusNotSolved_Solver_ortoolsswig_fe88f1954daf0526())
@@ -598,6 +621,7 @@ func _swig_getSolver_StatusNotSolved_Solver() (_swig_ret Operations_researchMPSo
 }
 
 var SolverStatusNotSolved Operations_researchMPSolverResultStatus = _swig_getSolver_StatusNotSolved_Solver()
+
 func (arg1 SwigcptrSolver) Solve__SWIG_0() (_swig_ret Operations_researchMPSolverResultStatus) {
 	var swig_r Operations_researchMPSolverResultStatus
 	_swig_i_0 := arg1
@@ -725,6 +749,7 @@ func (arg1 SwigcptrSolver) SetSolverSpecificParametersAsString(arg2 string) (_sw
 }
 
 type Operations_researchMPSolverBasisStatus int
+
 func _swig_getSolver_FREE_Solver() (_swig_ret Operations_researchMPSolverBasisStatus) {
 	var swig_r Operations_researchMPSolverBasisStatus
 	swig_r = (Operations_researchMPSolverBasisStatus)(C._wrap_FREE_Solver_ortoolsswig_fe88f1954daf0526())
@@ -732,6 +757,7 @@ func _swig_getSolver_FREE_Solver() (_swig_ret Operations_researchMPSolverBasisSt
 }
 
 var SolverFREE Operations_researchMPSolverBasisStatus = _swig_getSolver_FREE_Solver()
+
 func _swig_getSolver_AT_LOWER_BOUND_Solver() (_swig_ret Operations_researchMPSolverBasisStatus) {
 	var swig_r Operations_researchMPSolverBasisStatus
 	swig_r = (Operations_researchMPSolverBasisStatus)(C._wrap_AT_LOWER_BOUND_Solver_ortoolsswig_fe88f1954daf0526())
@@ -739,6 +765,7 @@ func _swig_getSolver_AT_LOWER_BOUND_Solver() (_swig_ret Operations_researchMPSol
 }
 
 var SolverAT_LOWER_BOUND Operations_researchMPSolverBasisStatus = _swig_getSolver_AT_LOWER_BOUND_Solver()
+
 func _swig_getSolver_AT_UPPER_BOUND_Solver() (_swig_ret Operations_researchMPSolverBasisStatus) {
 	var swig_r Operations_researchMPSolverBasisStatus
 	swig_r = (Operations_researchMPSolverBasisStatus)(C._wrap_AT_UPPER_BOUND_Solver_ortoolsswig_fe88f1954daf0526())
@@ -746,6 +773,7 @@ func _swig_getSolver_AT_UPPER_BOUND_Solver() (_swig_ret Operations_researchMPSol
 }
 
 var SolverAT_UPPER_BOUND Operations_researchMPSolverBasisStatus = _swig_getSolver_AT_UPPER_BOUND_Solver()
+
 func _swig_getSolver_FIXED_VALUE_Solver() (_swig_ret Operations_researchMPSolverBasisStatus) {
 	var swig_r Operations_researchMPSolverBasisStatus
 	swig_r = (Operations_researchMPSolverBasisStatus)(C._wrap_FIXED_VALUE_Solver_ortoolsswig_fe88f1954daf0526())
@@ -753,6 +781,7 @@ func _swig_getSolver_FIXED_VALUE_Solver() (_swig_ret Operations_researchMPSolver
 }
 
 var SolverFIXED_VALUE Operations_researchMPSolverBasisStatus = _swig_getSolver_FIXED_VALUE_Solver()
+
 func _swig_getSolver_BASIC_Solver() (_swig_ret Operations_researchMPSolverBasisStatus) {
 	var swig_r Operations_researchMPSolverBasisStatus
 	swig_r = (Operations_researchMPSolverBasisStatus)(C._wrap_BASIC_Solver_ortoolsswig_fe88f1954daf0526())
@@ -760,6 +789,7 @@ func _swig_getSolver_BASIC_Solver() (_swig_ret Operations_researchMPSolverBasisS
 }
 
 var SolverBASIC Operations_researchMPSolverBasisStatus = _swig_getSolver_BASIC_Solver()
+
 func SolverInfinity() (_swig_ret float64) {
 	var swig_r float64
 	swig_r = (float64)(C._wrap_Solver_infinity_ortoolsswig_fe88f1954daf0526())
@@ -824,7 +854,7 @@ func (arg1 SwigcptrSolver) LoadModelFromProto(arg2 Operations_research_MPModelPr
 	swig_r_p := C._wrap_Solver_LoadModelFromProto_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -835,7 +865,7 @@ func (arg1 SwigcptrSolver) ExportModelAsLpFormat(arg2 bool) (_swig_ret string) {
 	swig_r_p := C._wrap_Solver_ExportModelAsLpFormat_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0), C._Bool(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -847,7 +877,7 @@ func (arg1 SwigcptrSolver) ExportModelAsMpsFormat(arg2 bool, arg3 bool) (_swig_r
 	swig_r_p := C._wrap_Solver_ExportModelAsMpsFormat_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0), C._Bool(_swig_i_1), C._Bool(_swig_i_2))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1043,7 +1073,7 @@ func (arg1 SwigcptrVariable) Name() (_swig_ret string) {
 	swig_r_p := C._wrap_Variable_name_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1115,7 +1145,7 @@ func (arg1 SwigcptrVariable) X__str__() (_swig_ret string) {
 	swig_r_p := C._wrap_Variable___str___ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1125,7 +1155,7 @@ func (arg1 SwigcptrVariable) X__repr__() (_swig_ret string) {
 	swig_r_p := C._wrap_Variable___repr___ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1196,7 +1226,7 @@ func (arg1 SwigcptrConstraint) Name() (_swig_ret string) {
 	swig_r_p := C._wrap_Constraint_name_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1321,6 +1351,7 @@ func (p SwigcptrMPSolverParameters) SwigIsMPSolverParameters() {
 }
 
 type Operations_researchMPSolverParametersDoubleParam int
+
 func _swig_getMPSolverParameters_RELATIVE_MIP_GAP_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersDoubleParam) {
 	var swig_r Operations_researchMPSolverParametersDoubleParam
 	swig_r = (Operations_researchMPSolverParametersDoubleParam)(C._wrap_RELATIVE_MIP_GAP_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1328,6 +1359,7 @@ func _swig_getMPSolverParameters_RELATIVE_MIP_GAP_MPSolverParameters() (_swig_re
 }
 
 var MPSolverParametersRELATIVE_MIP_GAP Operations_researchMPSolverParametersDoubleParam = _swig_getMPSolverParameters_RELATIVE_MIP_GAP_MPSolverParameters()
+
 func _swig_getMPSolverParameters_PRIMAL_TOLERANCE_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersDoubleParam) {
 	var swig_r Operations_researchMPSolverParametersDoubleParam
 	swig_r = (Operations_researchMPSolverParametersDoubleParam)(C._wrap_PRIMAL_TOLERANCE_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1335,6 +1367,7 @@ func _swig_getMPSolverParameters_PRIMAL_TOLERANCE_MPSolverParameters() (_swig_re
 }
 
 var MPSolverParametersPRIMAL_TOLERANCE Operations_researchMPSolverParametersDoubleParam = _swig_getMPSolverParameters_PRIMAL_TOLERANCE_MPSolverParameters()
+
 func _swig_getMPSolverParameters_DUAL_TOLERANCE_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersDoubleParam) {
 	var swig_r Operations_researchMPSolverParametersDoubleParam
 	swig_r = (Operations_researchMPSolverParametersDoubleParam)(C._wrap_DUAL_TOLERANCE_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1342,7 +1375,9 @@ func _swig_getMPSolverParameters_DUAL_TOLERANCE_MPSolverParameters() (_swig_ret 
 }
 
 var MPSolverParametersDUAL_TOLERANCE Operations_researchMPSolverParametersDoubleParam = _swig_getMPSolverParameters_DUAL_TOLERANCE_MPSolverParameters()
+
 type Operations_researchMPSolverParametersIntegerParam int
+
 func _swig_getMPSolverParameters_PRESOLVE_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersIntegerParam) {
 	var swig_r Operations_researchMPSolverParametersIntegerParam
 	swig_r = (Operations_researchMPSolverParametersIntegerParam)(C._wrap_PRESOLVE_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1350,6 +1385,7 @@ func _swig_getMPSolverParameters_PRESOLVE_MPSolverParameters() (_swig_ret Operat
 }
 
 var MPSolverParametersPRESOLVE Operations_researchMPSolverParametersIntegerParam = _swig_getMPSolverParameters_PRESOLVE_MPSolverParameters()
+
 func _swig_getMPSolverParameters_LP_ALGORITHM_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersIntegerParam) {
 	var swig_r Operations_researchMPSolverParametersIntegerParam
 	swig_r = (Operations_researchMPSolverParametersIntegerParam)(C._wrap_LP_ALGORITHM_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1357,6 +1393,7 @@ func _swig_getMPSolverParameters_LP_ALGORITHM_MPSolverParameters() (_swig_ret Op
 }
 
 var MPSolverParametersLP_ALGORITHM Operations_researchMPSolverParametersIntegerParam = _swig_getMPSolverParameters_LP_ALGORITHM_MPSolverParameters()
+
 func _swig_getMPSolverParameters_INCREMENTALITY_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersIntegerParam) {
 	var swig_r Operations_researchMPSolverParametersIntegerParam
 	swig_r = (Operations_researchMPSolverParametersIntegerParam)(C._wrap_INCREMENTALITY_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1364,6 +1401,7 @@ func _swig_getMPSolverParameters_INCREMENTALITY_MPSolverParameters() (_swig_ret 
 }
 
 var MPSolverParametersINCREMENTALITY Operations_researchMPSolverParametersIntegerParam = _swig_getMPSolverParameters_INCREMENTALITY_MPSolverParameters()
+
 func _swig_getMPSolverParameters_SCALING_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersIntegerParam) {
 	var swig_r Operations_researchMPSolverParametersIntegerParam
 	swig_r = (Operations_researchMPSolverParametersIntegerParam)(C._wrap_SCALING_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1371,7 +1409,9 @@ func _swig_getMPSolverParameters_SCALING_MPSolverParameters() (_swig_ret Operati
 }
 
 var MPSolverParametersSCALING Operations_researchMPSolverParametersIntegerParam = _swig_getMPSolverParameters_SCALING_MPSolverParameters()
+
 type Operations_researchMPSolverParametersPresolveValues int
+
 func _swig_getMPSolverParameters_PRESOLVE_OFF_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersPresolveValues) {
 	var swig_r Operations_researchMPSolverParametersPresolveValues
 	swig_r = (Operations_researchMPSolverParametersPresolveValues)(C._wrap_PRESOLVE_OFF_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1379,6 +1419,7 @@ func _swig_getMPSolverParameters_PRESOLVE_OFF_MPSolverParameters() (_swig_ret Op
 }
 
 var MPSolverParametersPRESOLVE_OFF Operations_researchMPSolverParametersPresolveValues = _swig_getMPSolverParameters_PRESOLVE_OFF_MPSolverParameters()
+
 func _swig_getMPSolverParameters_PRESOLVE_ON_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersPresolveValues) {
 	var swig_r Operations_researchMPSolverParametersPresolveValues
 	swig_r = (Operations_researchMPSolverParametersPresolveValues)(C._wrap_PRESOLVE_ON_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1386,7 +1427,9 @@ func _swig_getMPSolverParameters_PRESOLVE_ON_MPSolverParameters() (_swig_ret Ope
 }
 
 var MPSolverParametersPRESOLVE_ON Operations_researchMPSolverParametersPresolveValues = _swig_getMPSolverParameters_PRESOLVE_ON_MPSolverParameters()
+
 type Operations_researchMPSolverParametersLpAlgorithmValues int
+
 func _swig_getMPSolverParameters_DUAL_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersLpAlgorithmValues) {
 	var swig_r Operations_researchMPSolverParametersLpAlgorithmValues
 	swig_r = (Operations_researchMPSolverParametersLpAlgorithmValues)(C._wrap_DUAL_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1394,6 +1437,7 @@ func _swig_getMPSolverParameters_DUAL_MPSolverParameters() (_swig_ret Operations
 }
 
 var MPSolverParametersDUAL Operations_researchMPSolverParametersLpAlgorithmValues = _swig_getMPSolverParameters_DUAL_MPSolverParameters()
+
 func _swig_getMPSolverParameters_PRIMAL_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersLpAlgorithmValues) {
 	var swig_r Operations_researchMPSolverParametersLpAlgorithmValues
 	swig_r = (Operations_researchMPSolverParametersLpAlgorithmValues)(C._wrap_PRIMAL_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1401,6 +1445,7 @@ func _swig_getMPSolverParameters_PRIMAL_MPSolverParameters() (_swig_ret Operatio
 }
 
 var MPSolverParametersPRIMAL Operations_researchMPSolverParametersLpAlgorithmValues = _swig_getMPSolverParameters_PRIMAL_MPSolverParameters()
+
 func _swig_getMPSolverParameters_BARRIER_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersLpAlgorithmValues) {
 	var swig_r Operations_researchMPSolverParametersLpAlgorithmValues
 	swig_r = (Operations_researchMPSolverParametersLpAlgorithmValues)(C._wrap_BARRIER_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1408,7 +1453,9 @@ func _swig_getMPSolverParameters_BARRIER_MPSolverParameters() (_swig_ret Operati
 }
 
 var MPSolverParametersBARRIER Operations_researchMPSolverParametersLpAlgorithmValues = _swig_getMPSolverParameters_BARRIER_MPSolverParameters()
+
 type Operations_researchMPSolverParametersIncrementalityValues int
+
 func _swig_getMPSolverParameters_INCREMENTALITY_OFF_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersIncrementalityValues) {
 	var swig_r Operations_researchMPSolverParametersIncrementalityValues
 	swig_r = (Operations_researchMPSolverParametersIncrementalityValues)(C._wrap_INCREMENTALITY_OFF_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1416,6 +1463,7 @@ func _swig_getMPSolverParameters_INCREMENTALITY_OFF_MPSolverParameters() (_swig_
 }
 
 var MPSolverParametersINCREMENTALITY_OFF Operations_researchMPSolverParametersIncrementalityValues = _swig_getMPSolverParameters_INCREMENTALITY_OFF_MPSolverParameters()
+
 func _swig_getMPSolverParameters_INCREMENTALITY_ON_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersIncrementalityValues) {
 	var swig_r Operations_researchMPSolverParametersIncrementalityValues
 	swig_r = (Operations_researchMPSolverParametersIncrementalityValues)(C._wrap_INCREMENTALITY_ON_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1423,7 +1471,9 @@ func _swig_getMPSolverParameters_INCREMENTALITY_ON_MPSolverParameters() (_swig_r
 }
 
 var MPSolverParametersINCREMENTALITY_ON Operations_researchMPSolverParametersIncrementalityValues = _swig_getMPSolverParameters_INCREMENTALITY_ON_MPSolverParameters()
+
 type Operations_researchMPSolverParametersScalingValues int
+
 func _swig_getMPSolverParameters_SCALING_OFF_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersScalingValues) {
 	var swig_r Operations_researchMPSolverParametersScalingValues
 	swig_r = (Operations_researchMPSolverParametersScalingValues)(C._wrap_SCALING_OFF_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1431,6 +1481,7 @@ func _swig_getMPSolverParameters_SCALING_OFF_MPSolverParameters() (_swig_ret Ope
 }
 
 var MPSolverParametersSCALING_OFF Operations_researchMPSolverParametersScalingValues = _swig_getMPSolverParameters_SCALING_OFF_MPSolverParameters()
+
 func _swig_getMPSolverParameters_SCALING_ON_MPSolverParameters() (_swig_ret Operations_researchMPSolverParametersScalingValues) {
 	var swig_r Operations_researchMPSolverParametersScalingValues
 	swig_r = (Operations_researchMPSolverParametersScalingValues)(C._wrap_SCALING_ON_MPSolverParameters_ortoolsswig_fe88f1954daf0526())
@@ -1438,6 +1489,7 @@ func _swig_getMPSolverParameters_SCALING_ON_MPSolverParameters() (_swig_ret Oper
 }
 
 var MPSolverParametersSCALING_ON Operations_researchMPSolverParametersScalingValues = _swig_getMPSolverParameters_SCALING_ON_MPSolverParameters()
+
 func GetMPSolverParametersKDefaultRelativeMipGap() (_swig_ret float64) {
 	var swig_r float64
 	swig_r = (float64)(C._wrap_MPSolverParameters_kDefaultRelativeMipGap_get_ortoolsswig_fe88f1954daf0526())
@@ -1550,7 +1602,7 @@ func ExportModelAsLpFormat__SWIG_0(arg1 Operations_research_MPModelProto, arg2 M
 	swig_r_p := C._wrap_ExportModelAsLpFormat__SWIG_0_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1560,7 +1612,7 @@ func ExportModelAsLpFormat__SWIG_1(arg1 Operations_research_MPModelProto) (_swig
 	swig_r_p := C._wrap_ExportModelAsLpFormat__SWIG_1_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1582,7 +1634,7 @@ func ExportModelAsMpsFormat__SWIG_0(arg1 Operations_research_MPModelProto, arg2 
 	swig_r_p := C._wrap_ExportModelAsMpsFormat__SWIG_0_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1592,7 +1644,7 @@ func ExportModelAsMpsFormat__SWIG_1(arg1 Operations_research_MPModelProto) (_swi
 	swig_r_p := C._wrap_ExportModelAsMpsFormat__SWIG_1_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
@@ -1613,80 +1665,87 @@ func FindErrorInModelProto(arg1 Operations_research_MPModelProto) (_swig_ret str
 	swig_r_p := C._wrap_FindErrorInModelProto_ortoolsswig_fe88f1954daf0526(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
- swig_r_1 = swigCopyString(swig_r) 
+	swig_r_1 = swigCopyString(swig_r)
 	return swig_r_1
 }
 
-
 type SwigcptrStd_vector_Sl_operations_research_MPConstraint_Sm__Sg_ uintptr
 type Std_vector_Sl_operations_research_MPConstraint_Sm__Sg_ interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrStd_vector_Sl_operations_research_MPConstraint_Sm__Sg_) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrOperations_research_MPModelProto uintptr
 type Operations_research_MPModelProto interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrOperations_research_MPModelProto) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrInt64 uintptr
 type Int64 interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrInt64) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrAbsl_Status uintptr
 type Absl_Status interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrAbsl_Status) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrStd_vector_Sl_operations_research_MPVariable_Sm__Sg_ uintptr
 type Std_vector_Sl_operations_research_MPVariable_Sm__Sg_ interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrStd_vector_Sl_operations_research_MPVariable_Sm__Sg_) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrStd_vector_Sl_double_Sg_ uintptr
 type Std_vector_Sl_double_Sg_ interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrStd_vector_Sl_double_Sg_) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrStd_atomic_Sl_bool_Sg_ uintptr
 type Std_atomic_Sl_bool_Sg_ interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrStd_atomic_Sl_bool_Sg_) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrOperations_research_MPSolutionResponse uintptr
 type Operations_research_MPSolutionResponse interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrOperations_research_MPSolutionResponse) Swigcptr() uintptr {
 	return uintptr(p)
 }
 
 type SwigcptrOperations_research_MPModelRequest uintptr
 type Operations_research_MPModelRequest interface {
-	Swigcptr() uintptr;
+	Swigcptr() uintptr
 }
+
 func (p SwigcptrOperations_research_MPModelRequest) Swigcptr() uintptr {
 	return uintptr(p)
 }
-


### PR DESCRIPTION
This PR has corrected the following points.
- **Remove the "ortools" folder in path (directly ortoolsswig)**:
The import _ortoolsswig_ in the `ortools.go` file has an extra folder on the path, it does not exist on the repo.
```c++
// Current import                                      // What is in the repo
├── or-tools-go                                       ├── or-tools-go
│       |── ortools.go                                │       |── ortools.go            
|       └── ortools                                   |       └── ortoolswig
|               └── ortoolswig
```
- **Add flag on ortoolsswig "C" import for correct compilation**:
To compile the `import "C"` in the file `ortoolsswig.go` the compiler uses the default routes in Linux `/lib`, `/usr/lib`, etc where the ortools libs should be included. However, nowhere it has specified the linker `-lortools`, this flag has been added. Otherwise, building a program that used ortools package, failed (in linking), as it needs to compile the C code in ortoolsswig too. As well, the flag to use `c++17` have been added.